### PR TITLE
remove unwanted parts from heise article header

### DIFF
--- a/config/heise.php
+++ b/config/heise.php
@@ -27,6 +27,10 @@ $config['search']	= array(
   "#<p class=\"forum\">.*</p>#Uis",
   "#<a href=\".*\" class=\"comment\" name=\"spalte.mac-and-i.forenbeitrag.[0-9]+\">.*</a>#Us",
   "#<div id=\"zett_kasten.*</div>#Uis",
+  # remove all parts of the header except the image
+  "#<header[^>]*class=\"article-header\"[^>]*>.*<figure[^>]*class=\"article-image\"[^>]*>(.*)</figure>.*</header>#Uis",
+  # remove elements like "stellenmarkt"
+  "#<a-collapse[^>]*>.*</a-collapse>#Uis",
   "#http://www.heise.de//#Uis"
   );
 $config['replace'] = array(
@@ -50,6 +54,8 @@ $config['replace'] = array(
   "",
   "",
   "",
+  "",
+  '${1}', # insert the image from the header
   "",
   "//"
   );

--- a/config/tagesspiegel.php
+++ b/config/tagesspiegel.php
@@ -12,9 +12,12 @@ $config['search']		= array('#<div[^>]*class="[^"]*ts-ad[^"]*"[^>]*>.*</div>#Uis'
 								'#<div class="ts-meta">.*</div>#Uis',
 								'#<h1[^>]*class="ts-title"[^>]*>.*</h1>#Uis',
 								'#<header[^>]*class="ts-article-header">.*<div[^>]*class="ts-subpage-header">.*</header>#Uis',
-								'#<div[^>]*class="ts-subpage-index">.*</a>.*</div>#Uis'
+								'#<div[^>]*class="ts-subpage-index">.*</a>.*</div>#Uis',
+								# remove "Tagesspiegel Checkpoint"
+								'#<figure[^>]*class="ts-checkpoint"[^>]*>.*</figure>#Uis'
 								);
 $config['replace']		= array('',
+								'',
 								'',
 								'',
 								'',


### PR DESCRIPTION
It includes removing the headline, a short lead paragraph and the header subline (reading time, icons)